### PR TITLE
  helm: allow overriding all garage.toml bind addresses from values

### DIFF
--- a/script/helm/garage/README.md
+++ b/script/helm/garage/README.md
@@ -35,8 +35,11 @@ S3-compatible object store for small self-hosted geo-distributed deployments
 | garage.metadataAutoSnapshotInterval | string | `""` | If this value is set, Garage will automatically take a snapshot of the metadata DB file at a regular interval and save it in the metadata directory. https://garagehq.deuxfleurs.fr/documentation/reference-manual/configuration/#metadata_auto_snapshot_interval |
 | garage.rpcBindAddr | string | `"[::]:3901"` |  |
 | garage.rpcSecret | string | `""` | If not given, a random secret will be generated and stored in a Secret object |
+| garage.admin.apiBindAddr | string | `"[::]:3903"` |  |
+| garage.s3.api.bindAddr | string | `"[::]:3900"` |  |
 | garage.s3.api.region | string | `"garage"` |  |
 | garage.s3.api.rootDomain | string | `".s3.garage.tld"` |  |
+| garage.s3.web.bindAddr | string | `"[::]:3902"` |  |
 | garage.s3.web.index | string | `"index.html"` |  |
 | garage.s3.web.rootDomain | string | `".web.garage.tld"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/script/helm/garage/templates/configmap.yaml
+++ b/script/helm/garage/templates/configmap.yaml
@@ -45,16 +45,16 @@ data:
 
     [s3_api]
     s3_region = "{{ .Values.garage.s3.api.region }}"
-    api_bind_addr = "[::]:3900"
+    api_bind_addr = "{{ .Values.garage.s3.api.bindAddr }}"
     root_domain = "{{ .Values.garage.s3.api.rootDomain }}"
 
     [s3_web]
-    bind_addr = "[::]:3902"
+    bind_addr = "{{ .Values.garage.s3.web.bindAddr }}"
     root_domain = "{{ .Values.garage.s3.web.rootDomain }}"
     index = "{{ .Values.garage.s3.web.index }}"
 
     [admin]
-    api_bind_addr = "[::]:3903"
+    api_bind_addr = "{{ .Values.garage.admin.apiBindAddr }}"
     {{- if .Values.monitoring.tracing.sink }}
     trace_sink = "{{ .Values.monitoring.tracing.sink }}"
     {{- end }}

--- a/script/helm/garage/values.yaml
+++ b/script/helm/garage/values.yaml
@@ -48,11 +48,15 @@ garage:
   kubernetesSkipCrd: false
   s3:
     api:
+      bindAddr: "[::]:3900"
       region: "garage"
       rootDomain: ".s3.garage.tld"
     web:
+      bindAddr: "[::]:3902"
       rootDomain: ".web.garage.tld"
       index: "index.html"
+  admin:
+    apiBindAddr: "[::]:3903"
 
   # -- Additional configuration to append to garage.toml. Use a multi-line string for custom config.
   # Example:


### PR DESCRIPTION
This PR is Helm-only and makes all bind addresses in the generated `garage.toml` configurable from chart values.

## Changes

- Updated `script/helm/garage/templates/configmap.yaml` to replace hardcoded:
  - `[s3_api].api_bind_addr = "[::]:3900"`
  - `[s3_web].bind_addr = "[::]:3902"`
  - `[admin].api_bind_addr = "[::]:3903"`
- Added new values in `script/helm/garage/values.yaml`:
  - `garage.s3.api.bindAddr` (default `"[::]:3900"`)
  - `garage.s3.web.bindAddr` (default `"[::]:3902"`)
  - `garage.admin.apiBindAddr` (default `"[::]:3903"`)
- Updated chart docs in `script/helm/garage/README.md`.

## Why

On clusters/nodes without IPv6 enabled, hardcoded [::] bind addresses can fail. This change allows setting IPv4 bind addresses via values (for example 0.0.0.0:3900/3902/3903).

